### PR TITLE
[fix] 処理順に関わらず、現在のフレームでダメージ判定・攻撃判定が行われたかを取得できるように

### DIFF
--- a/Assets/Prefabs/Base/UnitBase.prefab
+++ b/Assets/Prefabs/Base/UnitBase.prefab
@@ -313,6 +313,7 @@ MonoBehaviour:
   debugMode: 0
   health: {fileID: 1476775191128089322}
   owner: {fileID: 0}
+  registry: {fileID: 11400000, guid: 9489e0474ce11f74682b7c853798d4a9, type: 2}
 --- !u!114 &7778223179493459700
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Base/UnitBase.prefab
+++ b/Assets/Prefabs/Base/UnitBase.prefab
@@ -313,7 +313,7 @@ MonoBehaviour:
   debugMode: 0
   health: {fileID: 1476775191128089322}
   owner: {fileID: 0}
-  registry: {fileID: 11400000, guid: 9489e0474ce11f74682b7c853798d4a9, type: 2}
+  _registry: {fileID: 11400000, guid: 9489e0474ce11f74682b7c853798d4a9, type: 2}
 --- !u!114 &7778223179493459700
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/System/System.prefab
+++ b/Assets/Prefabs/System/System.prefab
@@ -62,6 +62,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 366adc83bba4b0847b35e13aa6a44520, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _hitManagerRegistry: {fileID: 11400000, guid: 9489e0474ce11f74682b7c853798d4a9, type: 2}
 --- !u!1 &8667081462346142718
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/System/System.prefab
+++ b/Assets/Prefabs/System/System.prefab
@@ -10,6 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2616280256819354239}
   - component: {fileID: 9180169309453971064}
+  - component: {fileID: 7921886895545172202}
   m_Layer: 0
   m_Name: System
   m_TagString: Untagged
@@ -49,6 +50,18 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _inventory: {fileID: 5497242811645433698}
   _entityManager: {fileID: 11400000, guid: 1b4198b73382bb1499a9674b0ee2ff72, type: 2}
+--- !u!114 &7921886895545172202
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5062815952536034031}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 366adc83bba4b0847b35e13aa6a44520, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &8667081462346142718
 GameObject:
   m_ObjectHideFlags: 0
@@ -226,6 +239,14 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 6962249653414236472, guid: 2b00d7b2610f6d24d9d9e206f416e785, type: 3}
+      propertyPath: canvasScaler
+      value: 
+      objectReference: {fileID: 9213439298733982907}
+    - target: {fileID: 6962249653414236472, guid: 2b00d7b2610f6d24d9d9e206f416e785, type: 3}
+      propertyPath: commandMenuGenerator
+      value: 
+      objectReference: {fileID: 1140762823951421758}
     - target: {fileID: 7212704492227819325, guid: 2b00d7b2610f6d24d9d9e206f416e785, type: 3}
       propertyPath: m_Name
       value: MouseControls
@@ -245,6 +266,10 @@ PrefabInstance:
     - target: {fileID: 7481132928463506354, guid: 2b00d7b2610f6d24d9d9e206f416e785, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402006989315559142, guid: 2b00d7b2610f6d24d9d9e206f416e785, type: 3}
+      propertyPath: selectableLayers.m_Bits
+      value: 1216
       objectReference: {fileID: 0}
     - target: {fileID: 8479391458340738090, guid: 2b00d7b2610f6d24d9d9e206f416e785, type: 3}
       propertyPath: m_AnchorMax.y
@@ -279,15 +304,129 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
+    m_RemovedGameObjects:
+    - {fileID: 5114557534690615758, guid: 2b00d7b2610f6d24d9d9e206f416e785, type: 3}
+    - {fileID: 5858676323661180653, guid: 2b00d7b2610f6d24d9d9e206f416e785, type: 3}
+    - {fileID: 442465057667051702, guid: 2b00d7b2610f6d24d9d9e206f416e785, type: 3}
+    - {fileID: 177517110807868490, guid: 2b00d7b2610f6d24d9d9e206f416e785, type: 3}
+    - {fileID: 6290906732937154134, guid: 2b00d7b2610f6d24d9d9e206f416e785, type: 3}
+    - {fileID: 4138459587960140788, guid: 2b00d7b2610f6d24d9d9e206f416e785, type: 3}
+    - {fileID: 1415643754833914213, guid: 2b00d7b2610f6d24d9d9e206f416e785, type: 3}
+    - {fileID: 7802338152873523982, guid: 2b00d7b2610f6d24d9d9e206f416e785, type: 3}
     m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 7212704492227819325, guid: 2b00d7b2610f6d24d9d9e206f416e785, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 3440022912442679951}
+    - targetCorrespondingSourceObject: {fileID: 7212704492227819325, guid: 2b00d7b2610f6d24d9d9e206f416e785, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1140762823951421758}
+    - targetCorrespondingSourceObject: {fileID: 7212704492227819325, guid: 2b00d7b2610f6d24d9d9e206f416e785, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 5347430803629739400}
   m_SourcePrefab: {fileID: 100100000, guid: 2b00d7b2610f6d24d9d9e206f416e785, type: 3}
+--- !u!114 &4037790277143214059 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1834429367715359220, guid: 2b00d7b2610f6d24d9d9e206f416e785, type: 3}
+  m_PrefabInstance: {fileID: 2412855277378493983}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5000266150174009634}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e7502f9f35390444fab7e8240e77106c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &4747583711405788967 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 6962249653414236472, guid: 2b00d7b2610f6d24d9d9e206f416e785, type: 3}
+  m_PrefabInstance: {fileID: 2412855277378493983}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5000266150174009634}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fd67e83ac5c68744a9d4fad7262b54a8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &5000266150174009634 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7212704492227819325, guid: 2b00d7b2610f6d24d9d9e206f416e785, type: 3}
+  m_PrefabInstance: {fileID: 2412855277378493983}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &3440022912442679951
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5000266150174009634}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b01e935b64d3725429301e0d21cd6ce2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _unitSelector: {fileID: 6189568492427186425}
+--- !u!114 &1140762823951421758
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5000266150174009634}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 76dea5276175e7e4caabbbc7470bc39a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _commandCollector: {fileID: 3440022912442679951}
+  _commandButtonFactory: {fileID: 5347430803629739400}
+  _unitController: {fileID: 4037790277143214059}
+  _unitControlMenu: {fileID: 4747583711405788967}
+--- !u!114 &5347430803629739400
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5000266150174009634}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4b9274b5c46ede745b6c40c007bc06c9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _commandButtonPrefab: {fileID: 6810179672237231343, guid: e5bf855ffe3a7184b8963824f9215b82, type: 3}
+  _menuParent: {fileID: 5616396407803470248}
+--- !u!224 &5616396407803470248 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 7822011283841335223, guid: 2b00d7b2610f6d24d9d9e206f416e785, type: 3}
+  m_PrefabInstance: {fileID: 2412855277378493983}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &6189568492427186425 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8402006989315559142, guid: 2b00d7b2610f6d24d9d9e206f416e785, type: 3}
+  m_PrefabInstance: {fileID: 2412855277378493983}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5000266150174009634}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 44fb873d30625e34b97b2d0a0e88d7f8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!4 &7669534772365250673 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 5409815095935241838, guid: 2b00d7b2610f6d24d9d9e206f416e785, type: 3}
   m_PrefabInstance: {fileID: 2412855277378493983}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &9213439298733982907 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 6818618256375126692, guid: 2b00d7b2610f6d24d9d9e206f416e785, type: 3}
+  m_PrefabInstance: {fileID: 2412855277378493983}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &7921333154484046451
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -298,6 +437,10 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1621575689634941309, guid: fe19852836dd205479056bdc8189cc16, type: 3}
       propertyPath: viewPrefab
+      value: 
+      objectReference: {fileID: 5447473488537624786, guid: 4077f2b2c02f29946bc3faf8091784b9, type: 3}
+    - target: {fileID: 1621575689634941309, guid: fe19852836dd205479056bdc8189cc16, type: 3}
+      propertyPath: nodeViewPrefab
       value: 
       objectReference: {fileID: 5447473488537624786, guid: 4077f2b2c02f29946bc3faf8091784b9, type: 3}
     - target: {fileID: 5510677804096618866, guid: fe19852836dd205479056bdc8189cc16, type: 3}

--- a/Assets/Scenes/HitEventTest.unity
+++ b/Assets/Scenes/HitEventTest.unity
@@ -2560,6 +2560,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: System
       objectReference: {fileID: 0}
+    - target: {fileID: 7921886895545172202, guid: afa0cdc38ada26640af53328e06b37f3, type: 3}
+      propertyPath: _hitManagerRegistry
+      value: 
+      objectReference: {fileID: 11400000, guid: 9489e0474ce11f74682b7c853798d4a9, type: 2}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []

--- a/Assets/Scenes/HitEventTest.unity
+++ b/Assets/Scenes/HitEventTest.unity
@@ -2560,10 +2560,6 @@ PrefabInstance:
       propertyPath: m_Name
       value: System
       objectReference: {fileID: 0}
-    - target: {fileID: 7921886895545172202, guid: afa0cdc38ada26640af53328e06b37f3, type: 3}
-      propertyPath: _hitManagerRegistry
-      value: 
-      objectReference: {fileID: 11400000, guid: 9489e0474ce11f74682b7c853798d4a9, type: 2}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []

--- a/Assets/Scenes/HitEventTest.unity
+++ b/Assets/Scenes/HitEventTest.unity
@@ -1,0 +1,2604 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 10
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 13
+  m_BakeOnSceneLoad: 0
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 1
+    m_PVRFilteringGaussRadiusAO: 1
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 20201, guid: 0000000000000000f000000000000000, type: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 3
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    buildHeightMesh: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1001 &63824193
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 601269608163708508, guid: d102b07fb2d3b704e985b68c1b4a4e6f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2.099218
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: d102b07fb2d3b704e985b68c1b4a4e6f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.0000019073486
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: d102b07fb2d3b704e985b68c1b4a4e6f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 9.761061
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: d102b07fb2d3b704e985b68c1b4a4e6f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: d102b07fb2d3b704e985b68c1b4a4e6f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: d102b07fb2d3b704e985b68c1b4a4e6f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: d102b07fb2d3b704e985b68c1b4a4e6f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: d102b07fb2d3b704e985b68c1b4a4e6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: d102b07fb2d3b704e985b68c1b4a4e6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: d102b07fb2d3b704e985b68c1b4a4e6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1858036909408944744, guid: d102b07fb2d3b704e985b68c1b4a4e6f, type: 3}
+      propertyPath: m_Name
+      value: NormalBee
+      objectReference: {fileID: 0}
+    - target: {fileID: 1858036909408944744, guid: d102b07fb2d3b704e985b68c1b4a4e6f, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 1858036909408944744, guid: d102b07fb2d3b704e985b68c1b4a4e6f, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 332855099}
+  m_SourcePrefab: {fileID: 100100000, guid: d102b07fb2d3b704e985b68c1b4a4e6f, type: 3}
+--- !u!1001 &64655698
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 601269608163708508, guid: 2e8ca9104d8361646a5d2a15aec5d3ec, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.57168484
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: 2e8ca9104d8361646a5d2a15aec5d3ec, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.0000019073486
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: 2e8ca9104d8361646a5d2a15aec5d3ec, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 5.234386
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: 2e8ca9104d8361646a5d2a15aec5d3ec, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: 2e8ca9104d8361646a5d2a15aec5d3ec, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: 2e8ca9104d8361646a5d2a15aec5d3ec, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: 2e8ca9104d8361646a5d2a15aec5d3ec, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: 2e8ca9104d8361646a5d2a15aec5d3ec, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: 2e8ca9104d8361646a5d2a15aec5d3ec, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: 2e8ca9104d8361646a5d2a15aec5d3ec, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1858036909408944744, guid: 2e8ca9104d8361646a5d2a15aec5d3ec, type: 3}
+      propertyPath: m_Name
+      value: SurgeBee
+      objectReference: {fileID: 0}
+    - target: {fileID: 1858036909408944744, guid: 2e8ca9104d8361646a5d2a15aec5d3ec, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 2e8ca9104d8361646a5d2a15aec5d3ec, type: 3}
+--- !u!1001 &83158516
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 601269608163708508, guid: 1cdfc62b832834343abb665291a30e6c, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.87875104
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: 1cdfc62b832834343abb665291a30e6c, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.0000019073486
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: 1cdfc62b832834343abb665291a30e6c, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 5.153747
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: 1cdfc62b832834343abb665291a30e6c, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: 1cdfc62b832834343abb665291a30e6c, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: 1cdfc62b832834343abb665291a30e6c, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: 1cdfc62b832834343abb665291a30e6c, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: 1cdfc62b832834343abb665291a30e6c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: 1cdfc62b832834343abb665291a30e6c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: 1cdfc62b832834343abb665291a30e6c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1858036909408944744, guid: 1cdfc62b832834343abb665291a30e6c, type: 3}
+      propertyPath: m_Name
+      value: QuantumBee
+      objectReference: {fileID: 0}
+    - target: {fileID: 1858036909408944744, guid: 1cdfc62b832834343abb665291a30e6c, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1cdfc62b832834343abb665291a30e6c, type: 3}
+--- !u!1001 &128059733
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 157237625251592788, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: destinationTag
+      value: Base
+      objectReference: {fileID: 0}
+    - target: {fileID: 1182542122783441271, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: '_actionAssets.Array.data[1]'
+      value: 
+      objectReference: {fileID: 11400000, guid: 4adc3edc9b40a4348afe5f79ee42c8ae, type: 2}
+    - target: {fileID: 7528061565457179345, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -11.67
+      objectReference: {fileID: 0}
+    - target: {fileID: 7528061565457179345, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.0000038146973
+      objectReference: {fileID: 0}
+    - target: {fileID: 7528061565457179345, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 3.73
+      objectReference: {fileID: 0}
+    - target: {fileID: 7528061565457179345, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7528061565457179345, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7528061565457179345, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7528061565457179345, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7528061565457179345, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7528061565457179345, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7528061565457179345, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8119121568251838326, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_Layer
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 8784338313791942373, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_Name
+      value: EnemyMelee
+      objectReference: {fileID: 0}
+    - target: {fileID: 8784338313791942373, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+--- !u!1001 &159617071
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 157237625251592788, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: destinationTag
+      value: Base
+      objectReference: {fileID: 0}
+    - target: {fileID: 1182542122783441271, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: '_actionAssets.Array.data[1]'
+      value: 
+      objectReference: {fileID: 11400000, guid: 4adc3edc9b40a4348afe5f79ee42c8ae, type: 2}
+    - target: {fileID: 7528061565457179345, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -15.3
+      objectReference: {fileID: 0}
+    - target: {fileID: 7528061565457179345, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.0000038146973
+      objectReference: {fileID: 0}
+    - target: {fileID: 7528061565457179345, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 11.3
+      objectReference: {fileID: 0}
+    - target: {fileID: 7528061565457179345, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7528061565457179345, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7528061565457179345, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7528061565457179345, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7528061565457179345, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7528061565457179345, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7528061565457179345, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8119121568251838326, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_Layer
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 8784338313791942373, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_Name
+      value: EnemyMelee (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8784338313791942373, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+--- !u!1001 &164784515
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 601269608163708508, guid: 988ab2ef3f019774bab0c42b12e28334, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2.7928824
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: 988ab2ef3f019774bab0c42b12e28334, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: 988ab2ef3f019774bab0c42b12e28334, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 5.8643217
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: 988ab2ef3f019774bab0c42b12e28334, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: 988ab2ef3f019774bab0c42b12e28334, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: 988ab2ef3f019774bab0c42b12e28334, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: 988ab2ef3f019774bab0c42b12e28334, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: 988ab2ef3f019774bab0c42b12e28334, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: 988ab2ef3f019774bab0c42b12e28334, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: 988ab2ef3f019774bab0c42b12e28334, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1858036909408944744, guid: 988ab2ef3f019774bab0c42b12e28334, type: 3}
+      propertyPath: m_Name
+      value: ConstructorBee
+      objectReference: {fileID: 0}
+    - target: {fileID: 1858036909408944744, guid: 988ab2ef3f019774bab0c42b12e28334, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 988ab2ef3f019774bab0c42b12e28334, type: 3}
+--- !u!1001 &328305515
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 601269608163708508, guid: 7d32d326da338e54d82a15d33812a743, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.28
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: 7d32d326da338e54d82a15d33812a743, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.0000038146973
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: 7d32d326da338e54d82a15d33812a743, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 8.64
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: 7d32d326da338e54d82a15d33812a743, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: 7d32d326da338e54d82a15d33812a743, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: 7d32d326da338e54d82a15d33812a743, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: 7d32d326da338e54d82a15d33812a743, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: 7d32d326da338e54d82a15d33812a743, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: 7d32d326da338e54d82a15d33812a743, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: 7d32d326da338e54d82a15d33812a743, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1858036909408944744, guid: 7d32d326da338e54d82a15d33812a743, type: 3}
+      propertyPath: m_Name
+      value: Destroyer Bee
+      objectReference: {fileID: 0}
+    - target: {fileID: 1858036909408944744, guid: 7d32d326da338e54d82a15d33812a743, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7d32d326da338e54d82a15d33812a743, type: 3}
+--- !u!1 &332855086 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1858036909408944744, guid: d102b07fb2d3b704e985b68c1b4a4e6f, type: 3}
+  m_PrefabInstance: {fileID: 63824193}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &332855092 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3780396806137709843, guid: d102b07fb2d3b704e985b68c1b4a4e6f, type: 3}
+  m_PrefabInstance: {fileID: 63824193}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 332855086}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e799b7be119e138449387215d6baa708, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &332855099
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 332855086}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: aa6d1cd5c494acd43ae2422b13d4ab76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  hitManager: {fileID: 332855092}
+--- !u!1001 &369366611
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 601269608163708508, guid: aa2333626e0998f46b1c84ee77488fad, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.15
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: aa2333626e0998f46b1c84ee77488fad, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: aa2333626e0998f46b1c84ee77488fad, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2.93
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: aa2333626e0998f46b1c84ee77488fad, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: aa2333626e0998f46b1c84ee77488fad, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: aa2333626e0998f46b1c84ee77488fad, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: aa2333626e0998f46b1c84ee77488fad, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: aa2333626e0998f46b1c84ee77488fad, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: aa2333626e0998f46b1c84ee77488fad, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: aa2333626e0998f46b1c84ee77488fad, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1858036909408944744, guid: aa2333626e0998f46b1c84ee77488fad, type: 3}
+      propertyPath: m_Name
+      value: SurgeonBee
+      objectReference: {fileID: 0}
+    - target: {fileID: 1858036909408944744, guid: aa2333626e0998f46b1c84ee77488fad, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: aa2333626e0998f46b1c84ee77488fad, type: 3}
+--- !u!1 &371957641
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 371957644}
+  - component: {fileID: 371957643}
+  - component: {fileID: 371957642}
+  m_Layer: 0
+  m_Name: Directional Light (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &371957642
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 371957641}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 474bcb49853aa07438625e644c072ee6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Version: 3
+  m_UsePipelineSettings: 1
+  m_AdditionalLightsShadowResolutionTier: 2
+  m_LightLayerMask: 1
+  m_RenderingLayers: 1
+  m_CustomShadowLayers: 0
+  m_ShadowLayerMask: 1
+  m_ShadowRenderingLayers: 1
+  m_LightCookieSize: {x: 1, y: 1}
+  m_LightCookieOffset: {x: 0, y: 0}
+  m_SoftShadowQuality: 0
+--- !u!108 &371957643
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 371957641}
+  m_Enabled: 1
+  serializedVersion: 11
+  m_Type: 1
+  m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 4
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_UseViewFrustumForShadowCasterCull: 1
+  m_ForceVisible: 0
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+  m_LightUnit: 1
+  m_LuxAtDistance: 1
+  m_EnableSpotReflector: 1
+--- !u!4 &371957644
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 371957641}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
+  m_LocalPosition: {x: 0, y: 3, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!1 &433722126
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 433722131}
+  - component: {fileID: 433722130}
+  - component: {fileID: 433722129}
+  - component: {fileID: 433722128}
+  - component: {fileID: 433722127}
+  m_Layer: 0
+  m_Name: Ground
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &433722127
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 433722126}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7a5ac11cc976e418e8d13136b07e1f52, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_SerializedVersion: 0
+  m_AgentTypeID: 0
+  m_CollectObjects: 0
+  m_Size: {x: 10, y: 10, z: 10}
+  m_Center: {x: 0, y: 2, z: 0}
+  m_LayerMask:
+    serializedVersion: 2
+    m_Bits: 55
+  m_UseGeometry: 1
+  m_DefaultArea: 0
+  m_GenerateLinks: 0
+  m_IgnoreNavMeshAgent: 1
+  m_IgnoreNavMeshObstacle: 1
+  m_OverrideTileSize: 0
+  m_TileSize: 256
+  m_OverrideVoxelSize: 0
+  m_VoxelSize: 0.16666667
+  m_MinRegionArea: 2
+  m_NavMeshData: {fileID: 23800000, guid: 71db679d36b053140bccf589756c2c04, type: 2}
+  m_BuildHeightMesh: 0
+--- !u!64 &433722128
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 433722126}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 5
+  m_Convex: 0
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &433722129
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 433722126}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &433722130
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 433722126}
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &433722131
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 433722126}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 10, y: 10, z: 10}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &474514072
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 7328467911758272174, guid: a02c5a78d5156444fad04121acdac699, type: 3}
+      propertyPath: m_Name
+      value: Flower
+      objectReference: {fileID: 0}
+    - target: {fileID: 8852218621138609954, guid: a02c5a78d5156444fad04121acdac699, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 8852218621138609954, guid: a02c5a78d5156444fad04121acdac699, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.0000019073486
+      objectReference: {fileID: 0}
+    - target: {fileID: 8852218621138609954, guid: a02c5a78d5156444fad04121acdac699, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -4.14
+      objectReference: {fileID: 0}
+    - target: {fileID: 8852218621138609954, guid: a02c5a78d5156444fad04121acdac699, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8852218621138609954, guid: a02c5a78d5156444fad04121acdac699, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8852218621138609954, guid: a02c5a78d5156444fad04121acdac699, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8852218621138609954, guid: a02c5a78d5156444fad04121acdac699, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8852218621138609954, guid: a02c5a78d5156444fad04121acdac699, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8852218621138609954, guid: a02c5a78d5156444fad04121acdac699, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8852218621138609954, guid: a02c5a78d5156444fad04121acdac699, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a02c5a78d5156444fad04121acdac699, type: 3}
+--- !u!1001 &521845373
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 601269608163708508, guid: d0464b25257273c4ab304b48f0ae924b, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 4.181459
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: d0464b25257273c4ab304b48f0ae924b, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.0000019073486
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: d0464b25257273c4ab304b48f0ae924b, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 8.147905
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: d0464b25257273c4ab304b48f0ae924b, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: d0464b25257273c4ab304b48f0ae924b, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: d0464b25257273c4ab304b48f0ae924b, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: d0464b25257273c4ab304b48f0ae924b, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: d0464b25257273c4ab304b48f0ae924b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: d0464b25257273c4ab304b48f0ae924b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: d0464b25257273c4ab304b48f0ae924b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1858036909408944744, guid: d0464b25257273c4ab304b48f0ae924b, type: 3}
+      propertyPath: m_Name
+      value: GatlingBee
+      objectReference: {fileID: 0}
+    - target: {fileID: 1858036909408944744, guid: d0464b25257273c4ab304b48f0ae924b, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d0464b25257273c4ab304b48f0ae924b, type: 3}
+--- !u!1001 &606095022
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 7528061565457179345, guid: 57ab3c4f6eb9a2b4f9d1378bd1e07867, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 7.93
+      objectReference: {fileID: 0}
+    - target: {fileID: 7528061565457179345, guid: 57ab3c4f6eb9a2b4f9d1378bd1e07867, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.0000019073486
+      objectReference: {fileID: 0}
+    - target: {fileID: 7528061565457179345, guid: 57ab3c4f6eb9a2b4f9d1378bd1e07867, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 8.7
+      objectReference: {fileID: 0}
+    - target: {fileID: 7528061565457179345, guid: 57ab3c4f6eb9a2b4f9d1378bd1e07867, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7528061565457179345, guid: 57ab3c4f6eb9a2b4f9d1378bd1e07867, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7528061565457179345, guid: 57ab3c4f6eb9a2b4f9d1378bd1e07867, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7528061565457179345, guid: 57ab3c4f6eb9a2b4f9d1378bd1e07867, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7528061565457179345, guid: 57ab3c4f6eb9a2b4f9d1378bd1e07867, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7528061565457179345, guid: 57ab3c4f6eb9a2b4f9d1378bd1e07867, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7528061565457179345, guid: 57ab3c4f6eb9a2b4f9d1378bd1e07867, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8784338313791942373, guid: 57ab3c4f6eb9a2b4f9d1378bd1e07867, type: 3}
+      propertyPath: m_Name
+      value: EnemyCharge
+      objectReference: {fileID: 0}
+    - target: {fileID: 8784338313791942373, guid: 57ab3c4f6eb9a2b4f9d1378bd1e07867, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 57ab3c4f6eb9a2b4f9d1378bd1e07867, type: 3}
+--- !u!1001 &725598718
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 601269608163708508, guid: a450676f4df072143bb3456f430f829d, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.942023
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: a450676f4df072143bb3456f430f829d, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: a450676f4df072143bb3456f430f829d, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 6.1314106
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: a450676f4df072143bb3456f430f829d, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: a450676f4df072143bb3456f430f829d, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: a450676f4df072143bb3456f430f829d, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: a450676f4df072143bb3456f430f829d, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: a450676f4df072143bb3456f430f829d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: a450676f4df072143bb3456f430f829d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: a450676f4df072143bb3456f430f829d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1858036909408944744, guid: a450676f4df072143bb3456f430f829d, type: 3}
+      propertyPath: m_Name
+      value: Soldier Bee
+      objectReference: {fileID: 0}
+    - target: {fileID: 1858036909408944744, guid: a450676f4df072143bb3456f430f829d, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a450676f4df072143bb3456f430f829d, type: 3}
+--- !u!1001 &743609972
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 601269608163708508, guid: b450eea2cca64a54d80979072fa5de83, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.92607737
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: b450eea2cca64a54d80979072fa5de83, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.0000019073486
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: b450eea2cca64a54d80979072fa5de83, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 6.5660405
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: b450eea2cca64a54d80979072fa5de83, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: b450eea2cca64a54d80979072fa5de83, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: b450eea2cca64a54d80979072fa5de83, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: b450eea2cca64a54d80979072fa5de83, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: b450eea2cca64a54d80979072fa5de83, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: b450eea2cca64a54d80979072fa5de83, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: b450eea2cca64a54d80979072fa5de83, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1858036909408944744, guid: b450eea2cca64a54d80979072fa5de83, type: 3}
+      propertyPath: m_Name
+      value: MedicBee
+      objectReference: {fileID: 0}
+    - target: {fileID: 1858036909408944744, guid: b450eea2cca64a54d80979072fa5de83, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b450eea2cca64a54d80979072fa5de83, type: 3}
+--- !u!1001 &871699800
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 601269608163708508, guid: 4fe259d044a156549adf47e770594761, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.24038792
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: 4fe259d044a156549adf47e770594761, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: 4fe259d044a156549adf47e770594761, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 9.7136755
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: 4fe259d044a156549adf47e770594761, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: 4fe259d044a156549adf47e770594761, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: 4fe259d044a156549adf47e770594761, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: 4fe259d044a156549adf47e770594761, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: 4fe259d044a156549adf47e770594761, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: 4fe259d044a156549adf47e770594761, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: 4fe259d044a156549adf47e770594761, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1858036909408944744, guid: 4fe259d044a156549adf47e770594761, type: 3}
+      propertyPath: m_Name
+      value: ScarBee
+      objectReference: {fileID: 0}
+    - target: {fileID: 1858036909408944744, guid: 4fe259d044a156549adf47e770594761, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 4fe259d044a156549adf47e770594761, type: 3}
+--- !u!1 &906000775
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 906000779}
+  - component: {fileID: 906000778}
+  - component: {fileID: 906000777}
+  - component: {fileID: 906000776}
+  m_Layer: 0
+  m_Name: CinemachineCamera
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &906000776
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 906000775}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4afa82ae3200b82408d605c3dbdd1e38, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Damping: 0
+--- !u!114 &906000777
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 906000775}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 886251e9a18ece04ea8e61686c173e1b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  CameraDistance: 20
+  DeadZoneDepth: 0
+  Composition:
+    ScreenPosition: {x: 0, y: 0}
+    DeadZone:
+      Enabled: 0
+      Size: {x: 0.2, y: 0.2}
+    HardLimits:
+      Enabled: 0
+      Size: {x: 0.8, y: 0.8}
+      Offset: {x: 0, y: 0}
+  CenterOnActivate: 1
+  TargetOffset: {x: 0, y: 0, z: 0}
+  Damping: {x: 0.5, y: 0.5, z: 0.5}
+  Lookahead:
+    Enabled: 0
+    Time: 0
+    Smoothing: 0
+    IgnoreY: 0
+--- !u!114 &906000778
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 906000775}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f9dfa5b682dcd46bda6128250e975f58, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Priority:
+    Enabled: 0
+    m_Value: 0
+  OutputChannel: 1
+  StandbyUpdate: 2
+  m_StreamingVersion: 20241001
+  m_LegacyPriority: 0
+  Target:
+    TrackingTarget: {fileID: 1167655717}
+    LookAtTarget: {fileID: 0}
+    CustomLookAtTarget: 0
+  Lens:
+    FieldOfView: 30
+    OrthographicSize: 5
+    NearClipPlane: 0.3
+    FarClipPlane: 1000
+    Dutch: 0
+    ModeOverride: 0
+    PhysicalProperties:
+      GateFit: 2
+      SensorSize: {x: 21.946, y: 16.002}
+      LensShift: {x: 0, y: 0}
+      FocusDistance: 10
+      Iso: 200
+      ShutterSpeed: 0.005
+      Aperture: 16
+      BladeCount: 5
+      Curvature: {x: 2, y: 11}
+      BarrelClipping: 0.25
+      Anamorphism: 0
+  BlendHint: 0
+--- !u!4 &906000779
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 906000775}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -20}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 65, y: 45, z: 0}
+--- !u!1001 &963705467
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 601269608163708508, guid: 3627c3dfe030a8b499b8ce93b895cf1b, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -8.19
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: 3627c3dfe030a8b499b8ce93b895cf1b, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.0000019073486
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: 3627c3dfe030a8b499b8ce93b895cf1b, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 7.13
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: 3627c3dfe030a8b499b8ce93b895cf1b, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: 3627c3dfe030a8b499b8ce93b895cf1b, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: 3627c3dfe030a8b499b8ce93b895cf1b, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: 3627c3dfe030a8b499b8ce93b895cf1b, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: 3627c3dfe030a8b499b8ce93b895cf1b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: 3627c3dfe030a8b499b8ce93b895cf1b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: 3627c3dfe030a8b499b8ce93b895cf1b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1325741633937889041, guid: 3627c3dfe030a8b499b8ce93b895cf1b, type: 3}
+      propertyPath: m_AutoBraking
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1325741633937889041, guid: 3627c3dfe030a8b499b8ce93b895cf1b, type: 3}
+      propertyPath: m_StoppingDistance
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1858036909408944744, guid: 3627c3dfe030a8b499b8ce93b895cf1b, type: 3}
+      propertyPath: m_Name
+      value: QueenBee
+      objectReference: {fileID: 0}
+    - target: {fileID: 1858036909408944744, guid: 3627c3dfe030a8b499b8ce93b895cf1b, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8090739088979602938, guid: 3627c3dfe030a8b499b8ce93b895cf1b, type: 3}
+      propertyPath: _debugMode
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 3627c3dfe030a8b499b8ce93b895cf1b, type: 3}
+--- !u!1 &1167655716
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1167655717}
+  - component: {fileID: 1167655718}
+  m_Layer: 0
+  m_Name: CameraTarget
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1167655717
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1167655716}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1167655718
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1167655716}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3ed6bcd8afabd4842b126950c9dcbedc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  cameraInputManager: {fileID: 11400000, guid: 709f2906fddd1bc4f927d2dd1d64d8f5, type: 2}
+  cineCamera: {fileID: 906000778}
+  terrainLayer:
+    serializedVersion: 2
+    m_Bits: 0
+  horizontalPosition: {x: 0, y: 0, z: 0}
+  rotate: {x: 45, y: 45, z: 0}
+  distance: 20
+  speed: 5
+  zoomSpeed: 50
+  minDistance: 10
+  maxDistance: 35
+--- !u!1001 &1310435819
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 601269608163708508, guid: 6db6234e6546c9e46aeab925bbcba43d, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1.08318
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: 6db6234e6546c9e46aeab925bbcba43d, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.0000019073486
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: 6db6234e6546c9e46aeab925bbcba43d, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 12.696907
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: 6db6234e6546c9e46aeab925bbcba43d, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: 6db6234e6546c9e46aeab925bbcba43d, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: 6db6234e6546c9e46aeab925bbcba43d, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: 6db6234e6546c9e46aeab925bbcba43d, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: 6db6234e6546c9e46aeab925bbcba43d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: 6db6234e6546c9e46aeab925bbcba43d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: 6db6234e6546c9e46aeab925bbcba43d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1858036909408944744, guid: 6db6234e6546c9e46aeab925bbcba43d, type: 3}
+      propertyPath: m_Name
+      value: ReconBee
+      objectReference: {fileID: 0}
+    - target: {fileID: 1858036909408944744, guid: 6db6234e6546c9e46aeab925bbcba43d, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 6db6234e6546c9e46aeab925bbcba43d, type: 3}
+--- !u!1001 &1318917787
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 601269608163708508, guid: e27413f10ea27ea47b1669da94671e00, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3.46
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: e27413f10ea27ea47b1669da94671e00, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: e27413f10ea27ea47b1669da94671e00, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.17
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: e27413f10ea27ea47b1669da94671e00, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: e27413f10ea27ea47b1669da94671e00, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: e27413f10ea27ea47b1669da94671e00, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: e27413f10ea27ea47b1669da94671e00, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: e27413f10ea27ea47b1669da94671e00, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: e27413f10ea27ea47b1669da94671e00, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: e27413f10ea27ea47b1669da94671e00, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1858036909408944744, guid: e27413f10ea27ea47b1669da94671e00, type: 3}
+      propertyPath: m_Name
+      value: SniperBee
+      objectReference: {fileID: 0}
+    - target: {fileID: 1858036909408944744, guid: e27413f10ea27ea47b1669da94671e00, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e27413f10ea27ea47b1669da94671e00, type: 3}
+--- !u!1001 &1362048317
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 157237625251592788, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: destinationTag
+      value: Base
+      objectReference: {fileID: 0}
+    - target: {fileID: 1182542122783441271, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: '_actionAssets.Array.data[1]'
+      value: 
+      objectReference: {fileID: 11400000, guid: 4adc3edc9b40a4348afe5f79ee42c8ae, type: 2}
+    - target: {fileID: 7528061565457179345, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.3
+      objectReference: {fileID: 0}
+    - target: {fileID: 7528061565457179345, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.0000038146973
+      objectReference: {fileID: 0}
+    - target: {fileID: 7528061565457179345, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 20.3
+      objectReference: {fileID: 0}
+    - target: {fileID: 7528061565457179345, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7528061565457179345, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7528061565457179345, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7528061565457179345, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7528061565457179345, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7528061565457179345, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7528061565457179345, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8119121568251838326, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_Layer
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 8784338313791942373, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_Name
+      value: EnemyMelee (3)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8784338313791942373, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+--- !u!1001 &1455768569
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 157237625251592788, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: destinationTag
+      value: Base
+      objectReference: {fileID: 0}
+    - target: {fileID: 1182542122783441271, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: '_actionAssets.Array.data[1]'
+      value: 
+      objectReference: {fileID: 11400000, guid: 4adc3edc9b40a4348afe5f79ee42c8ae, type: 2}
+    - target: {fileID: 7528061565457179345, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 13.39
+      objectReference: {fileID: 0}
+    - target: {fileID: 7528061565457179345, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.0000038146973
+      objectReference: {fileID: 0}
+    - target: {fileID: 7528061565457179345, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 13.07
+      objectReference: {fileID: 0}
+    - target: {fileID: 7528061565457179345, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7528061565457179345, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7528061565457179345, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7528061565457179345, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7528061565457179345, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7528061565457179345, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7528061565457179345, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8119121568251838326, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_Layer
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 8784338313791942373, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_Name
+      value: EnemyMelee (5)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8784338313791942373, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+--- !u!1001 &1491551925
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 601269608163708508, guid: e23c98d0dddaee043bf73ab830a61aa6, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.0974712
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: e23c98d0dddaee043bf73ab830a61aa6, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.0000019073486
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: e23c98d0dddaee043bf73ab830a61aa6, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 7.795785
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: e23c98d0dddaee043bf73ab830a61aa6, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: e23c98d0dddaee043bf73ab830a61aa6, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: e23c98d0dddaee043bf73ab830a61aa6, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: e23c98d0dddaee043bf73ab830a61aa6, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: e23c98d0dddaee043bf73ab830a61aa6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: e23c98d0dddaee043bf73ab830a61aa6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: e23c98d0dddaee043bf73ab830a61aa6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1858036909408944744, guid: e23c98d0dddaee043bf73ab830a61aa6, type: 3}
+      propertyPath: m_Name
+      value: BuilderBee
+      objectReference: {fileID: 0}
+    - target: {fileID: 1858036909408944744, guid: e23c98d0dddaee043bf73ab830a61aa6, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e23c98d0dddaee043bf73ab830a61aa6, type: 3}
+--- !u!1 &1677440812
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1677440817}
+  - component: {fileID: 1677440816}
+  - component: {fileID: 1677440815}
+  - component: {fileID: 1677440814}
+  - component: {fileID: 1677440813}
+  m_Layer: 0
+  m_Name: Main Camera (1)
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1677440813
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1677440812}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 72ece51f2901e7445ab60da3685d6b5f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ShowDebugText: 0
+  ShowCameraFrustum: 1
+  IgnoreTimeScale: 0
+  WorldUpOverride: {fileID: 0}
+  ChannelMask: -1
+  UpdateMethod: 2
+  BlendUpdateMethod: 1
+  LensModeOverride:
+    Enabled: 0
+    DefaultMode: 2
+  DefaultBlend:
+    Style: 1
+    Time: 2
+    CustomCurve:
+      serializedVersion: 2
+      m_Curve: []
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+  CustomBlends: {fileID: 0}
+--- !u!114 &1677440814
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1677440812}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_RenderShadows: 1
+  m_RequiresDepthTextureOption: 2
+  m_RequiresOpaqueTextureOption: 2
+  m_CameraType: 0
+  m_Cameras: []
+  m_RendererIndex: -1
+  m_VolumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 128
+  m_VolumeTrigger: {fileID: 0}
+  m_VolumeFrameworkUpdateModeOption: 2
+  m_RenderPostProcessing: 1
+  m_Antialiasing: 0
+  m_AntialiasingQuality: 2
+  m_StopNaN: 0
+  m_Dithering: 0
+  m_ClearDepth: 1
+  m_AllowXRRendering: 1
+  m_AllowHDROutput: 1
+  m_UseScreenCoordOverride: 0
+  m_ScreenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
+  m_RequiresDepthTexture: 0
+  m_RequiresColorTexture: 0
+  m_Version: 2
+  m_TaaSettings:
+    m_Quality: 3
+    m_FrameInfluence: 0.1
+    m_JitterScale: 1
+    m_MipBias: 0
+    m_VarianceClampScale: 0.9
+    m_ContrastAdaptiveSharpening: 0
+--- !u!81 &1677440815
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1677440812}
+  m_Enabled: 1
+--- !u!20 &1677440816
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1677440812}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 30
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &1677440817
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1677440812}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -20}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1709884460
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1709884463}
+  - component: {fileID: 1709884462}
+  - component: {fileID: 1709884461}
+  m_Layer: 0
+  m_Name: EventSystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1709884461
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1709884460}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 01614664b831546d2ae94a42149d80ac, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_SendPointerHoverToParent: 1
+  m_MoveRepeatDelay: 0.5
+  m_MoveRepeatRate: 0.1
+  m_XRTrackingOrigin: {fileID: 0}
+  m_ActionsAsset: {fileID: -944628639613478452, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_PointAction: {fileID: -1654692200621890270, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_MoveAction: {fileID: -8784545083839296357, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_SubmitAction: {fileID: 392368643174621059, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_CancelAction: {fileID: 7727032971491509709, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_LeftClickAction: {fileID: 3001919216989983466, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_MiddleClickAction: {fileID: -2185481485913320682, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_RightClickAction: {fileID: -4090225696740746782, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_ScrollWheelAction: {fileID: 6240969308177333660, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_TrackedDevicePositionAction: {fileID: 6564999863303420839, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_TrackedDeviceOrientationAction: {fileID: 7970375526676320489, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_DeselectOnBackgroundClick: 1
+  m_PointerBehavior: 0
+  m_CursorLockBehavior: 0
+  m_ScrollDeltaPerTick: 6
+--- !u!114 &1709884462
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1709884460}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_FirstSelected: {fileID: 0}
+  m_sendNavigationEvents: 1
+  m_DragThreshold: 10
+--- !u!4 &1709884463
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1709884460}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1813070346
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 601269608163708508, guid: e6072bc4ac862914586b7c9a433bd067, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: e6072bc4ac862914586b7c9a433bd067, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: e6072bc4ac862914586b7c9a433bd067, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: e6072bc4ac862914586b7c9a433bd067, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: e6072bc4ac862914586b7c9a433bd067, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: e6072bc4ac862914586b7c9a433bd067, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: e6072bc4ac862914586b7c9a433bd067, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: e6072bc4ac862914586b7c9a433bd067, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: e6072bc4ac862914586b7c9a433bd067, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: e6072bc4ac862914586b7c9a433bd067, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1858036909408944744, guid: e6072bc4ac862914586b7c9a433bd067, type: 3}
+      propertyPath: m_Name
+      value: TrapperBee
+      objectReference: {fileID: 0}
+    - target: {fileID: 1858036909408944744, guid: e6072bc4ac862914586b7c9a433bd067, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e6072bc4ac862914586b7c9a433bd067, type: 3}
+--- !u!1001 &1840924134
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 601269608163708508, guid: bc93c15c60554d54792903503883d76f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3.332241
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: bc93c15c60554d54792903503883d76f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.0000019073486
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: bc93c15c60554d54792903503883d76f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 3.8668652
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: bc93c15c60554d54792903503883d76f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: bc93c15c60554d54792903503883d76f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: bc93c15c60554d54792903503883d76f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: bc93c15c60554d54792903503883d76f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: bc93c15c60554d54792903503883d76f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: bc93c15c60554d54792903503883d76f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: bc93c15c60554d54792903503883d76f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1858036909408944744, guid: bc93c15c60554d54792903503883d76f, type: 3}
+      propertyPath: m_Name
+      value: WorkerBee
+      objectReference: {fileID: 0}
+    - target: {fileID: 1858036909408944744, guid: bc93c15c60554d54792903503883d76f, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: bc93c15c60554d54792903503883d76f, type: 3}
+--- !u!1001 &1875689983
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 157237625251592788, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: destinationTag
+      value: Base
+      objectReference: {fileID: 0}
+    - target: {fileID: 1182542122783441271, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: '_actionAssets.Array.data[1]'
+      value: 
+      objectReference: {fileID: 11400000, guid: 4adc3edc9b40a4348afe5f79ee42c8ae, type: 2}
+    - target: {fileID: 7528061565457179345, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 9.3
+      objectReference: {fileID: 0}
+    - target: {fileID: 7528061565457179345, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.0000038146973
+      objectReference: {fileID: 0}
+    - target: {fileID: 7528061565457179345, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 23.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7528061565457179345, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7528061565457179345, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7528061565457179345, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7528061565457179345, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7528061565457179345, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7528061565457179345, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7528061565457179345, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8119121568251838326, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_Layer
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 8784338313791942373, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_Name
+      value: EnemyMelee (4)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8784338313791942373, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+--- !u!1001 &1948042508
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 157237625251592788, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: destinationTag
+      value: Base
+      objectReference: {fileID: 0}
+    - target: {fileID: 1182542122783441271, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: '_actionAssets.Array.data[1]'
+      value: 
+      objectReference: {fileID: 11400000, guid: 4adc3edc9b40a4348afe5f79ee42c8ae, type: 2}
+    - target: {fileID: 7528061565457179345, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7528061565457179345, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.0000038146973
+      objectReference: {fileID: 0}
+    - target: {fileID: 7528061565457179345, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 16.3
+      objectReference: {fileID: 0}
+    - target: {fileID: 7528061565457179345, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7528061565457179345, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7528061565457179345, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7528061565457179345, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7528061565457179345, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7528061565457179345, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7528061565457179345, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8119121568251838326, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_Layer
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 8784338313791942373, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_Name
+      value: EnemyMelee (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8784338313791942373, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 8784338313791942373, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2024206204}
+  m_SourcePrefab: {fileID: 100100000, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+--- !u!1 &2017187928
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2017187929}
+  m_Layer: 0
+  m_Name: ===Stage===
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2017187929
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2017187928}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -5.273821, y: 18.085892, z: -14.718746}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2024206194 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8784338313791942373, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+  m_PrefabInstance: {fileID: 1948042508}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &2024206197 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 6077472747172309406, guid: 3cb188f3798b1084da555d4ce8217112, type: 3}
+  m_PrefabInstance: {fileID: 1948042508}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2024206194}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e799b7be119e138449387215d6baa708, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &2024206204
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2024206194}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: aa6d1cd5c494acd43ae2422b13d4ab76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  hitManager: {fileID: 2024206197}
+--- !u!1001 &2045695604
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 601269608163708508, guid: f8377a96403c3664eabbb54520c2603e, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2.2922878
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: f8377a96403c3664eabbb54520c2603e, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.000011444092
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: f8377a96403c3664eabbb54520c2603e, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 6.0704155
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: f8377a96403c3664eabbb54520c2603e, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: f8377a96403c3664eabbb54520c2603e, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: f8377a96403c3664eabbb54520c2603e, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: f8377a96403c3664eabbb54520c2603e, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: f8377a96403c3664eabbb54520c2603e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: f8377a96403c3664eabbb54520c2603e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 601269608163708508, guid: f8377a96403c3664eabbb54520c2603e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1858036909408944744, guid: f8377a96403c3664eabbb54520c2603e, type: 3}
+      propertyPath: m_Name
+      value: SaintBee
+      objectReference: {fileID: 0}
+    - target: {fileID: 1858036909408944744, guid: f8377a96403c3664eabbb54520c2603e, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: f8377a96403c3664eabbb54520c2603e, type: 3}
+--- !u!1001 &3647653551386609798
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2616280256819354239, guid: afa0cdc38ada26640af53328e06b37f3, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2616280256819354239, guid: afa0cdc38ada26640af53328e06b37f3, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2616280256819354239, guid: afa0cdc38ada26640af53328e06b37f3, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2616280256819354239, guid: afa0cdc38ada26640af53328e06b37f3, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2616280256819354239, guid: afa0cdc38ada26640af53328e06b37f3, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2616280256819354239, guid: afa0cdc38ada26640af53328e06b37f3, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2616280256819354239, guid: afa0cdc38ada26640af53328e06b37f3, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2616280256819354239, guid: afa0cdc38ada26640af53328e06b37f3, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2616280256819354239, guid: afa0cdc38ada26640af53328e06b37f3, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2616280256819354239, guid: afa0cdc38ada26640af53328e06b37f3, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5062815952536034031, guid: afa0cdc38ada26640af53328e06b37f3, type: 3}
+      propertyPath: m_Name
+      value: System
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: afa0cdc38ada26640af53328e06b37f3, type: 3}
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 1167655717}
+  - {fileID: 371957644}
+  - {fileID: 906000779}
+  - {fileID: 1677440817}
+  - {fileID: 3647653551386609798}
+  - {fileID: 1709884463}
+  - {fileID: 2017187929}
+  - {fileID: 433722131}
+  - {fileID: 128059733}
+  - {fileID: 159617071}
+  - {fileID: 1362048317}
+  - {fileID: 1875689983}
+  - {fileID: 1455768569}
+  - {fileID: 1948042508}
+  - {fileID: 606095022}
+  - {fileID: 725598718}
+  - {fileID: 328305515}
+  - {fileID: 1310435819}
+  - {fileID: 1318917787}
+  - {fileID: 521845373}
+  - {fileID: 63824193}
+  - {fileID: 1813070346}
+  - {fileID: 871699800}
+  - {fileID: 743609972}
+  - {fileID: 83158516}
+  - {fileID: 369366611}
+  - {fileID: 963705467}
+  - {fileID: 64655698}
+  - {fileID: 1491551925}
+  - {fileID: 164784515}
+  - {fileID: 2045695604}
+  - {fileID: 1840924134}
+  - {fileID: 474514072}

--- a/Assets/Scenes/HitEventTest.unity.meta
+++ b/Assets/Scenes/HitEventTest.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 5721a97a9b3e002418c25684cb6b2ab6
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/Registry.meta
+++ b/Assets/ScriptableObjects/Registry.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8238f4442fcdf764d8238d80f16c19d9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/Registry/HitManagerRegistry.asset
+++ b/Assets/ScriptableObjects/Registry/HitManagerRegistry.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 01e38f48c8b9f7241961e1e3e376c9ad, type: 3}
+  m_Name: HitManagerRegistry
+  m_EditorClassIdentifier: 

--- a/Assets/ScriptableObjects/Registry/HitManagerRegistry.asset.meta
+++ b/Assets/ScriptableObjects/Registry/HitManagerRegistry.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9489e0474ce11f74682b7c853798d4a9
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/HitControls/HitEventManager.cs
+++ b/Assets/Scripts/HitControls/HitEventManager.cs
@@ -1,3 +1,4 @@
+﻿using System.Linq;
 using UnityEngine;
 
 [DefaultExecutionOrder((int)ExecutionOrder.HitEventManager)]
@@ -5,9 +6,19 @@ public class HitEventManager : MonoBehaviour
 {
     [SerializeField] HitManagerRegistry _hitManagerRegistry;
 
+    private void Awake()
+    {
+        if (_hitManagerRegistry == null)
+        {
+            Debug.LogWarning("HitEventManager: HitManagerRegistryがアサインされていません");
+        }
+    }
+
     void Update()
     {
-        foreach (var hitManager in _hitManagerRegistry.Instances)
+        if (_hitManagerRegistry == null) return;
+
+        foreach (var hitManager in _hitManagerRegistry.Instances.ToList())
         {
             hitManager.ClearHitStates();
         }

--- a/Assets/Scripts/HitControls/HitEventManager.cs
+++ b/Assets/Scripts/HitControls/HitEventManager.cs
@@ -3,16 +3,11 @@ using UnityEngine;
 [DefaultExecutionOrder((int)ExecutionOrder.HitEventManager)]
 public class HitEventManager : MonoBehaviour
 {
-    HitManager[] _hitManagers;
-
-    void Start()
-    {
-        _hitManagers = FindObjectsByType<HitManager>(FindObjectsSortMode.None);
-    }
+    [SerializeField] HitManagerRegistry _hitManagerRegistry;
 
     void Update()
     {
-        foreach (var hitManager in _hitManagers)
+        foreach (var hitManager in _hitManagerRegistry.Instances)
         {
             hitManager.ClearHitStates();
         }

--- a/Assets/Scripts/HitControls/HitEventManager.cs
+++ b/Assets/Scripts/HitControls/HitEventManager.cs
@@ -1,0 +1,20 @@
+using UnityEngine;
+
+[DefaultExecutionOrder((int)ExecutionOrder.HitEventManager)]
+public class HitEventManager : MonoBehaviour
+{
+    HitManager[] _hitManagers;
+
+    void Start()
+    {
+        _hitManagers = FindObjectsByType<HitManager>(FindObjectsSortMode.None);
+    }
+
+    void Update()
+    {
+        foreach (var hitManager in _hitManagers)
+        {
+            hitManager.ClearHitStates();
+        }
+    }
+}

--- a/Assets/Scripts/HitControls/HitEventManager.cs.meta
+++ b/Assets/Scripts/HitControls/HitEventManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 366adc83bba4b0847b35e13aa6a44520

--- a/Assets/Scripts/HitControls/HitManager.cs
+++ b/Assets/Scripts/HitControls/HitManager.cs
@@ -58,11 +58,14 @@ public class HitManager : MonoBehaviour
         }
     }
 
-    private void Update()
+    public void ClearHitStates()
     {
         IsDamaged = false;
         IsAttacked = false;
+    }
 
+    private void Update()
+    {
         foreach (var info in _attackReceiveInfos)
         {
             ApplyHit(info);

--- a/Assets/Scripts/HitControls/HitManager.cs
+++ b/Assets/Scripts/HitControls/HitManager.cs
@@ -149,7 +149,7 @@ public class DamageHistoryManager
     public void Update()
     {
         var dt = Time.deltaTime;
-        for (int i = 0; i < damageHistories.Count; i++)
+        for (int i = damageHistories.Count - 1; i >= 0; i--)
         {
             damageHistories[i].duration -= dt;
             if (damageHistories[i].duration <= 0)

--- a/Assets/Scripts/HitControls/HitManager.cs
+++ b/Assets/Scripts/HitControls/HitManager.cs
@@ -101,7 +101,13 @@ public class HitManager : MonoBehaviour
 
     private void OnDisable()
     {
-        _registry?.Unregister(this);
+        if (_registry == null)
+        {
+            Debug.LogWarning("HitManager: HitManagerRegistryがアサインされていません", this);
+            return;
+        }
+
+        _registry.Unregister(this);
     }
 }
 

--- a/Assets/Scripts/HitControls/HitManager.cs
+++ b/Assets/Scripts/HitControls/HitManager.cs
@@ -8,7 +8,7 @@ public class HitManager : MonoBehaviour
     [SerializeField] bool debugMode;
     [SerializeField] Health health;
     [SerializeField] UnitBase owner;
-    [SerializeField] HitManagerRegistry registry;
+    [SerializeField] HitManagerRegistry _registry;
 
     readonly DamageHistoryManager damageHistoryManager = new();
 
@@ -90,12 +90,18 @@ public class HitManager : MonoBehaviour
 
     private void OnEnable()
     {
-        registry.Register(this);
+        if (_registry == null)
+        {
+            Debug.LogWarning("HitManager: HitManagerRegistryがアサインされていません", this);
+            return;
+        }
+
+        _registry.Register(this);
     }
 
     private void OnDisable()
     {
-        registry.Unregister(this);
+        _registry?.Unregister(this);
     }
 }
 

--- a/Assets/Scripts/HitControls/HitManager.cs
+++ b/Assets/Scripts/HitControls/HitManager.cs
@@ -8,6 +8,7 @@ public class HitManager : MonoBehaviour
     [SerializeField] bool debugMode;
     [SerializeField] Health health;
     [SerializeField] UnitBase owner;
+    [SerializeField] HitManagerRegistry registry;
 
     readonly DamageHistoryManager damageHistoryManager = new();
 
@@ -85,6 +86,16 @@ public class HitManager : MonoBehaviour
         {
             if (debugMode) Debug.Log($"Attacked: {info.damage} damage to {gameObject.name} from {info.attacker.name} with ID {info.id}");
         };
+    }
+
+    private void OnEnable()
+    {
+        registry.Register(this);
+    }
+
+    private void OnDisable()
+    {
+        registry.Unregister(this);
     }
 }
 

--- a/Assets/Scripts/Registry.meta
+++ b/Assets/Scripts/Registry.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 736f285db768e3d47a94a6bd4bfa39a3
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Registry/GameInstanceRegistry.cs
+++ b/Assets/Scripts/Registry/GameInstanceRegistry.cs
@@ -9,11 +9,25 @@ public abstract class GameInstanceRegistry<T> : ScriptableObject
 
     public void Register(T instance)
     {
-        _instances.Add(instance);
+        if (instance == null)
+        {
+            Debug.LogWarning($"{GetType()}: Attempted to register a null instance");
+            return;
+        }
+
+        if (!_instances.Add(instance))
+        {
+            Debug.LogWarning($"{GetType()}: Instance {typeof(T).Name} is already registered");
+        }
     }
 
     public void Unregister(T instance)
     {
+        if (instance == null)
+        {
+            Debug.LogWarning($"{GetType()}: Attempted to unregister a null instance from registry");
+            return;
+        }
         _instances.Remove(instance);
     }
 }

--- a/Assets/Scripts/Registry/GameInstanceRegistry.cs
+++ b/Assets/Scripts/Registry/GameInstanceRegistry.cs
@@ -28,6 +28,10 @@ public abstract class GameInstanceRegistry<T> : ScriptableObject
             Debug.LogWarning($"{GetType()}: Attempted to unregister a null instance from registry");
             return;
         }
-        _instances.Remove(instance);
+
+        if (!_instances.Remove(instance))
+        {
+            Debug.LogWarning($"{GetType()}: Instance {typeof(T).Name} was not found in registry");
+        }
     }
 }

--- a/Assets/Scripts/Registry/GameInstanceRegistry.cs
+++ b/Assets/Scripts/Registry/GameInstanceRegistry.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+public abstract class GameInstanceRegistry<T> : ScriptableObject
+{
+    readonly HashSet<T> _instances = new();
+
+    public IReadOnlyCollection<T> Instances => _instances;
+
+    public void Register(T instance)
+    {
+        _instances.Add(instance);
+    }
+
+    public void Unregister(T instance)
+    {
+        _instances.Remove(instance);
+    }
+}

--- a/Assets/Scripts/Registry/GameInstanceRegistry.cs.meta
+++ b/Assets/Scripts/Registry/GameInstanceRegistry.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 024fceeefffe4f740a31e146a8b3d34a

--- a/Assets/Scripts/Registry/HitManagerRegistry.cs
+++ b/Assets/Scripts/Registry/HitManagerRegistry.cs
@@ -1,0 +1,7 @@
+using UnityEngine;
+
+[CreateAssetMenu(fileName = "HitManagerRegistry", menuName = "Registry/HitManagerRegistry")]
+public class HitManagerRegistry : GameInstanceRegistry<HitManager>
+{
+    
+}

--- a/Assets/Scripts/Registry/HitManagerRegistry.cs.meta
+++ b/Assets/Scripts/Registry/HitManagerRegistry.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 01e38f48c8b9f7241961e1e3e376c9ad

--- a/Assets/Scripts/Tester/Test_HitDetection.cs
+++ b/Assets/Scripts/Tester/Test_HitDetection.cs
@@ -1,0 +1,18 @@
+using UnityEngine;
+
+public class Test_HitDetection : MonoBehaviour
+{
+    [SerializeField] HitManager hitManager;
+
+    void Update()
+    {
+        if (hitManager.IsAttacked)
+        {
+            Debug.Log($"{name} has been attacked!");
+        }
+        if (hitManager.IsDamaged)
+        {
+            Debug.Log($"{name} has taken damage!");
+        }
+    }
+}

--- a/Assets/Scripts/Tester/Test_HitDetection.cs.meta
+++ b/Assets/Scripts/Tester/Test_HitDetection.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: aa6d1cd5c494acd43ae2422b13d4ab76

--- a/Assets/Scripts/Utility/ExecutionOrder.cs
+++ b/Assets/Scripts/Utility/ExecutionOrder.cs
@@ -1,5 +1,6 @@
 ﻿public enum ExecutionOrder
 {
+    HitManager = -1,
     GameManager = 0,
     UnitController,
     UnitSelector,

--- a/Assets/Scripts/Utility/ExecutionOrder.cs
+++ b/Assets/Scripts/Utility/ExecutionOrder.cs
@@ -1,5 +1,6 @@
 ﻿public enum ExecutionOrder
 {
+    HitEventManager = -2,
     HitManager = -1,
     GameManager = 0,
     UnitController,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

**新機能**
* ヒット受信をインスタンスごとにキュー化してフレーム内でまとめて適用する遅延処理を導入しました。
* ヒット管理の中央レジストリと、登録／一括状態クリアを行う自動実行コンポーネントを追加しました。
* 実行順の指定にヒット関連の順序を追加しました。

**バグ修正**
* ダメージ履歴の削除処理を安全に行うよう改善しました。

**テスト**
* ヒット検出のデバッグ用スクリプトを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->